### PR TITLE
Nps update

### DIFF
--- a/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
@@ -7,13 +7,13 @@ local colorrange = function(val,range,color1,color2)
     return lerp_color( (val/range), color1, color2  )
 end
 
-local peak,npst,NMeasure,mcount = 0,{},{},0
+local peak,npst,streamlikeMeasures,measureCount = 0,{},{},0
 
 local GetStreamBreakdown = function(Player)
     if GAMESTATE:GetCurrentSong() and GAMESTATE:GetCurrentSteps(Player) then
-        local streams = LoadModule("Chart.GetStreamMeasure.lua")(NMeasure, 2, mcount)
+        local streams = LoadModule("Chart.GetStreamMeasure.lua")(streamlikeMeasures, 2, measureCount)
         if not streams then return "" end
-        
+
         local streamLengths = {}
         
         for i, stream in ipairs(streams) do
@@ -24,6 +24,7 @@ local GetStreamBreakdown = function(Player)
         end
         
         return table.concat(streamLengths, "/")
+        
     end
     return ""
 end
@@ -53,15 +54,15 @@ local amv = Def.ActorFrame{
                 if GAMESTATE:GetCurrentSong() and GAMESTATE:IsHumanPlayer(pn) and GAMESTATE:GetCurrentSteps(pn) then
                     -- Grab every instance of the NPS data.
                     local step = GAMESTATE:GetCurrentSteps(pn)
-                    peak,npst,NMeasure = LoadModule("Chart.GetNPS.lua")( step )
-				    if npst then
-					    for t ,v in pairs( npst ) do
-							local x = scale( t, 0, #npst,
+                    peak,nps = LoadModule("Chart.GetNPS.lua")( step )
+                    streamlikeMeasures, measureCount = LoadModule("Chart.GetStreamlikeMeasures.lua")( step )
+				    if nps then
+					    for t ,v in pairs( nps ) do
+							local x = scale( t, 0, #nps,
 								-(p2paneoffset/2)+5, (p2paneoffset/2)-5
 							)
 							-- Now scale that position on v to the y coordinate.
                             local y = math.round( scale( v, 0, peak, 60, -50 ) )
-                            Trace("t x y = " .. t .. " " .. x .. " " .. y)
 							if y < -50 then y = -50 end
                             local colrange = colorrange( v, peak, ColorDarkTone(PlayerColor(pn)), Color.Purple )
 							-- And send them to the table to be rendered.

--- a/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
@@ -53,17 +53,15 @@ local amv = Def.ActorFrame{
                 if GAMESTATE:GetCurrentSong() and GAMESTATE:IsHumanPlayer(pn) and GAMESTATE:GetCurrentSteps(pn) then
                     -- Grab every instance of the NPS data.
                     local step = GAMESTATE:GetCurrentSteps(pn)
-                    peak,npst,NMeasure,mcount = LoadModule("Chart.GetNPS.lua")( step )
+                    peak,npst,NMeasure = LoadModule("Chart.GetNPS.lua")( step )
 				    if npst then
-					    for k,v in pairs( npst ) do
-							-- Each NPS area is per MEASURE. not beat. So multiply the area by 4 beats.
-							local t = step:GetTimingData():GetElapsedTimeFromBeat((k-1)*4)
-							-- With this conversion on t, we now apply it to the x coordinate.
-							local x = scale( t, math.min(step:GetTimingData():GetElapsedTimeFromBeat(0), 0), GAMESTATE:GetCurrentSong():GetLastSecond(),
+					    for t ,v in pairs( npst ) do
+							local x = scale( t, 0, #npst,
 								-(p2paneoffset/2)+5, (p2paneoffset/2)-5
 							)
 							-- Now scale that position on v to the y coordinate.
                             local y = math.round( scale( v, 0, peak, 60, -50 ) )
+                            Trace("t x y = " .. t .. " " .. x .. " " .. y)
 							if y < -50 then y = -50 end
                             local colrange = colorrange( v, peak, ColorDarkTone(PlayerColor(pn)), Color.Purple )
 							-- And send them to the table to be rendered.

--- a/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
+++ b/BGAnimations/ScreenSelectMusic decorations/NPSDiagram.lua
@@ -13,7 +13,6 @@ local GetStreamBreakdown = function(Player)
     if GAMESTATE:GetCurrentSong() and GAMESTATE:GetCurrentSteps(Player) then
         local streams = LoadModule("Chart.GetStreamMeasure.lua")(streamlikeMeasures, 2, measureCount)
         if not streams then return "" end
-
         local streamLengths = {}
         
         for i, stream in ipairs(streams) do
@@ -23,8 +22,7 @@ local GetStreamBreakdown = function(Player)
             end
         end
         
-        return table.concat(streamLengths, "/")
-        
+        return table.concat(streamLengths, "/")  
     end
     return ""
 end

--- a/Modules/Chart.GetNPS.lua
+++ b/Modules/Chart.GetNPS.lua
@@ -8,17 +8,15 @@ local allowedNotes = {
 	["TapNoteType_HoldTail"] = true,
 }
 
-local minimumNotesInStreamMeasure = 16
 local movingAverageSectionSeconds = 2
 
 -- returns
 -- peak NPS (number)
 -- note density (table of seconds : NPS)
--- stream measures (table of measures : bool)
 return function(steps)
 
 	if not steps then
-		return 0, {}, {} 
+		return 0, {}
 	end
 
 	-- this is kinda meh, no? 
@@ -71,7 +69,6 @@ return function(steps)
 		end 
 	end
 
-	return peakNPS, movingAverage, {}
-
+	return peakNPS, movingAverage
 
 end

--- a/Modules/Chart.GetNPS.lua
+++ b/Modules/Chart.GetNPS.lua
@@ -9,74 +9,69 @@ local allowedNotes = {
 }
 
 local minimumNotesInStreamMeasure = 16
+local movingAverageSectionSeconds = 2
 
+-- returns
+-- peak NPS (number)
+-- note density (table of seconds : NPS)
+-- stream measures (table of measures : bool)
 return function(steps)
-	local chartInt = 1
-	local density = {}
-	local streamMeasures = {}
-	local peakNPS = 0
-	-- Keep track of processed measures
-	local measureCount = 0
 
-	if steps then
-		for k, v in pairs(GAMESTATE:GetCurrentSong():GetAllSteps()) do
-			if v == steps then
-				chartInt = k
-				break
-			end
-		end
-		-- Trace("[GetNPS] Loading Chart... ".. chartInt)
-		local timingData = steps:GetTimingData()
-
-		local function CalcNPS(measure)
-			-- Some Warp segments can fall into parts where the duration of the lasting beat before its next one
-			-- is miniscule, so lets just skip those.
-			if measure.duration <= 0.05 then
-				return 0
-			end
-
-			return measure.notes / measure.duration
-		end
-
-		-- Keep track of the number of notes in the current measure while we iterate
-		local function NewMeasure(index)
-			local endingTime = timingData:GetElapsedTimeFromBeat(index * 4)
-			return {
-				notes = 0,
-				NPS = 0,
-				endingTime = endingTime,
-				duration = endingTime - timingData:GetElapsedTimeFromBeat((index - 1) * 4)
-			}
-		end
-
-		local currentMeasure = NewMeasure(measureCount + 1)
-
-		for _, noteData in pairs(GAMESTATE:GetCurrentSong():GetNoteData(chartInt)) do
-			noteBeat, _, noteType = unpack(noteData)
-
-			while timingData:GetElapsedTimeFromBeat(noteBeat) > currentMeasure.endingTime do
-				local originalValue = currentMeasure.notes == 0 and 0 or CalcNPS(currentMeasure)
-				currentMeasure.NPS = math.round(originalValue)
-				peakNPS = (currentMeasure.NPS > peakNPS or originalValue > peakNPS) and originalValue or peakNPS
-
-				if (currentMeasure.notes >= minimumNotesInStreamMeasure) then
-					streamMeasures[#streamMeasures + 1] = measureCount + 1
-				end
-
-				-- Reset stuff
-				density[measureCount + 1] = currentMeasure.NPS
-				measureCount = measureCount + 1
-				currentMeasure = NewMeasure(measureCount + 1)
-			end
-
-			if timingData:IsJudgableAtBeat(noteBeat) and allowedNotes[noteType] then
-				currentMeasure.notes = currentMeasure.notes + 1
-			end
-		end
-
-		density[measureCount + 1] = currentMeasure.NPS
-		density[measureCount + 2] = 0
+	if not steps then
+		return 0, {}, {} 
 	end
 
-	return peakNPS, density, streamMeasures, measureCount
+	-- this is kinda meh, no? 
+	local chartInt = 1
+	for k, v in pairs(GAMESTATE:GetCurrentSong():GetAllSteps()) do
+		if v == steps then
+			chartInt = k
+			break
+		end
+	end
+
+	local timingData = steps:GetTimingData()
+	local lastSecond = math.ceil(GAMESTATE:GetCurrentSong():GetLastSecond())
+
+	notesInSecond = {}
+
+	for _, noteData in pairs(GAMESTATE:GetCurrentSong():GetNoteData(chartInt)) do
+
+		noteBeat, _, noteType = unpack(noteData)
+
+		if not timingData:IsJudgableAtBeat(noteBeat) or not allowedNotes[noteType] then
+			goto continue
+		end
+
+		noteTime = timingData:GetElapsedTimeFromBeat(noteBeat)
+		notesInSecond[ math.ceil(noteTime) ] = (notesInSecond[ math.ceil(noteTime) ] or 0) + 1
+
+		::continue::
+
+	end
+
+	local movingAverage = {}
+	local notesInMovingWindow = 0
+
+	for sec = 1, lastSecond do
+	
+		notesInMovingWindow = notesInMovingWindow + (notesInSecond[sec] or 0)
+
+		if sec >= movingAverageSectionSeconds then
+			notesInMovingWindow = notesInMovingWindow - (notesInSecond[ sec - movingAverageSectionSeconds ] or 0)
+		end
+
+		movingAverage[sec] = notesInMovingWindow / movingAverageSectionSeconds
+	end
+
+	local peakNPS = 0
+	for _, nps in pairs(movingAverage) do
+		if nps > peakNPS then
+			peakNPS = nps
+		end 
+	end
+
+	return peakNPS, movingAverage, {}
+
+
 end

--- a/Modules/Chart.GetStreamlikeMeasures.lua
+++ b/Modules/Chart.GetStreamlikeMeasures.lua
@@ -1,0 +1,79 @@
+local allowedNotes = {
+	["TapNoteType_Tap"] = true,
+	["TapNoteType_Lift"] = true,
+	-- Support the heads of the subtypes.
+	["TapNoteSubType_Hold"] = true,
+	["TapNoteSubType_Roll"] = true,
+	-- Stamina players: you'd want to comment this out.
+	["TapNoteType_HoldTail"] = true,
+}
+
+local minimumNotesInStreamMeasure = 16
+
+-- returns
+-- list of measures with >= minimumNotesInStreamMeasure notes (table of index : measure number)
+-- number of measures in the song (number)
+return function(steps)
+
+	if not steps then
+		return {}, 0
+	end
+
+	-- this is kinda meh, no? 
+	local chartInt = 1
+	for k, v in pairs(GAMESTATE:GetCurrentSong():GetAllSteps()) do
+		if v == steps then
+			chartInt = k
+			break
+		end
+	end
+
+	local timingData = steps:GetTimingData()
+
+	notesInMeasure = {}
+	local maxMeasure = 0
+
+	for _, noteData in pairs(GAMESTATE:GetCurrentSong():GetNoteData(chartInt)) do
+
+		noteBeat, _, noteType = unpack(noteData)
+
+		if not timingData:IsJudgableAtBeat(noteBeat) or not allowedNotes[noteType] then
+			goto continue
+		end
+
+		measureNumber = math.floor((noteBeat - 1) / 4) + 1
+
+		if measureNumber > maxMeasure then
+			maxMeasure = measureNumber
+		end
+
+		notesInMeasure[measureNumber] = (notesInMeasure[measureNumber] or 0) + 1
+
+		::continue::
+
+	end
+
+	local streamlikeMeasures = {}
+
+	for measure, notes in pairs(notesInMeasure) do
+		if notes >= minimumNotesInStreamMeasure then
+			streamlikeMeasures[#streamlikeMeasures + 1] = measure
+		end
+	end
+
+	function dump(o)
+	   if type(o) == 'table' then
+	      local s = '{ '
+	      for k,v in pairs(o) do
+	         if type(k) ~= 'number' then k = '"'..k..'"' end
+	         s = s .. '['..k..'] = ' .. dump(v) .. ','
+	      end
+	      return s .. '} '
+	   else
+	      return tostring(o)
+	   end
+	end
+
+	return streamlikeMeasures, maxMeasure
+
+end

--- a/Modules/Chart.GetStreamlikeMeasures.lua
+++ b/Modules/Chart.GetStreamlikeMeasures.lua
@@ -61,19 +61,6 @@ return function(steps)
 		end
 	end
 
-	function dump(o)
-	   if type(o) == 'table' then
-	      local s = '{ '
-	      for k,v in pairs(o) do
-	         if type(k) ~= 'number' then k = '"'..k..'"' end
-	         s = s .. '['..k..'] = ' .. dump(v) .. ','
-	      end
-	      return s .. '} '
-	   else
-	      return tostring(o)
-	   end
-	end
-
 	return streamlikeMeasures, maxMeasure
 
 end


### PR DESCRIPTION
NPS graph now uses 2s moving average instead of 'per measure', which had bugs when warps were involved.